### PR TITLE
Alterações na página de leitura e restauração do código original

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,27 @@
-# Getting Started with Create React App
+# Manga-DexApp
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+Manga-DexApp é um site de leitura de mangás online desenvolvido em ReactJS usando a API do MangaDex a documentação dessa API você pode encontrar no site [API mangaDex](https://api.mangadex.org/). Este projeto permite que os usuários visualizem uma lista de mangás, vejam detalhes sobre cada mangá e leiam capítulos específicos.
+Além disso está buscando resultados em Português-Br, ignorei os outros idiomas.
 
-## Available Scripts
 
-In the project directory, you can run:
+## Funcionalidades
 
-### `npm start`
+- Listar mangás populares
+- Visualizar detalhes de um mangá específico
+- Ler capítulos de mangás
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+## Tecnologias Utilizadas
 
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
+- ReactJS
+- Axios
+- React Router
+- CSS
 
-### `npm test`
+[Veja o site online aqui](https://mangadex-app.vercel.app/)
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+##
 
-### `npm run build`
+Desenvolvido como estudo por [Seimon Athayde](https://github.com/Cbih939)
+## Licença
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+Este projeto está licenciado sob a Licença MIT - veja o arquivo [LICENSE](LICENSE) para mais detalhes.

--- a/src/pages/ChapterDetail.js
+++ b/src/pages/ChapterDetail.js
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import './MangaRead.css';
+
+const ChapterDetail = ({ chapters, id, setSelectedChapter }) => {
+  const { chapterId } = useParams();
+  const navigate = useNavigate();
+  const [chapter, setChapter] = useState(null);
+  const [pages, setPages] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchChapter = async () => {
+      try {
+        const response = await axios.get(`https://api.mangadex.org/chapter/${chapterId}`);
+        setChapter(response.data.data);
+
+        const pagesResponse = await axios.get(`https://api.mangadex.org/at-home/server/${chapterId}`);
+        const baseUrl = pagesResponse.data.baseUrl;
+        const pageFiles = pagesResponse.data.chapter.data;
+        setPages(pageFiles.map(file => `${baseUrl}/data/${pagesResponse.data.chapter.hash}/${file}`));
+      } catch (error) {
+        console.error('Error fetching chapter:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchChapter();
+
+  }, [chapterId]);
+
+  const getNextChapter = () => {
+    const currentIndex = chapters.findIndex(chap => chap.id === chapterId);
+    const nextChapter = chapters[currentIndex + 1];
+    return nextChapter ? nextChapter.id : null;
+  };
+
+  const getPreviousChapter = () => {
+    const currentIndex = chapters.findIndex(chap => chap.id === chapterId);
+    const previousChapter = chapters[currentIndex - 1];
+    return previousChapter ? previousChapter.id : null;
+  };
+
+  const handlePreviousChapter = () => {
+    const previousChapterId = getPreviousChapter();
+    if (previousChapterId) {
+      navigate(`/manga/${id}/read/${previousChapterId}`);
+      setSelectedChapter(previousChapterId);
+      localStorage.setItem(`lastReadChapter-${id}`, previousChapterId);
+      document.getElementById('header').scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
+  const handleNextChapter = () => {
+    const nextChapterId = getNextChapter();
+    if (nextChapterId) {
+      navigate(`/manga/${id}/read/${nextChapterId}`);
+      setSelectedChapter(nextChapterId);
+      localStorage.setItem(`lastReadChapter-${id}`, nextChapterId);
+      document.getElementById('header').scrollIntoView({ behavior: 'smooth' });
+    }
+
+  };
+
+  if (loading) {
+
+    return <div>Carregando...</div>;
+  }
+
+  if (!chapter) {
+    return <div>Error loading chapter details.</div>;
+  }
+
+  return (
+    <div className="chapter-detail">
+      <h2>{chapter.attributes.title || `Chapter ${chapter.attributes.chapter}`}</h2>
+      <div className="chapter-pages">
+        {pages.map((page, index) => (
+          <img
+            key={index}
+            src={page}
+            alt={`Page ${index + 1}`}
+            className="chapter-page"
+          />
+        ))}
+      </div>
+      <div className='button-container'>
+        <button
+          onClick={handlePreviousChapter}
+          disabled={!getPreviousChapter()}
+          className="chapter-button"
+        >
+          Capítulo Anterior
+        </button>
+
+        <button
+          onClick={handleNextChapter}
+          disabled={!getNextChapter()}
+          className="chapter-button"
+        >
+          Próximo Capítulo
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ChapterDetail;

--- a/src/pages/ChapterDetail.js
+++ b/src/pages/ChapterDetail.js
@@ -30,16 +30,18 @@ const ChapterDetail = ({ chapters, id, setSelectedChapter }) => {
 
   }, [chapterId]);
 
+  const getCurrentChapterIndex = () => {
+    return chapters.findIndex(chap => chap.id === chapterId);
+  };
+
   const getNextChapter = () => {
-    const currentIndex = chapters.findIndex(chap => chap.id === chapterId);
-    const nextChapter = chapters[currentIndex + 1];
-    return nextChapter ? nextChapter.id : null;
+    const currentIndex = getCurrentChapterIndex();
+    return currentIndex < chapters.length - 1 ? chapters[currentIndex + 1].id : null;
   };
 
   const getPreviousChapter = () => {
-    const currentIndex = chapters.findIndex(chap => chap.id === chapterId);
-    const previousChapter = chapters[currentIndex - 1];
-    return previousChapter ? previousChapter.id : null;
+    const currentIndex = getCurrentChapterIndex();
+    return currentIndex > 0 ? chapters[currentIndex - 1].id : null;
   };
 
   const handlePreviousChapter = () => {
@@ -60,8 +62,8 @@ const ChapterDetail = ({ chapters, id, setSelectedChapter }) => {
       localStorage.setItem(`lastReadChapter-${id}`, nextChapterId);
       document.getElementById('header').scrollIntoView({ behavior: 'smooth' });
     }
-
   };
+
 
   if (loading) {
 

--- a/src/pages/MangaRead.css
+++ b/src/pages/MangaRead.css
@@ -56,14 +56,14 @@
 }
 
 .button-container {
-  display: flex; /* Ensure buttons are laid out in a row */
+  display: flex; 
   justify-content: center;
 }
 
 .button-container .chapter-button:first-of-type {
-  margin-right: 10px; /* Add margin to the right of the first button */
+  margin-right: 10px; 
 }
 
 .button-container .chapter-button:last-of-type {
-  margin-left: 10px; /* Add margin to the left of the second button */
+  margin-left: 10px; 
 }

--- a/src/pages/MangaRead.css
+++ b/src/pages/MangaRead.css
@@ -45,3 +45,25 @@
   max-width: 800px;
   margin-bottom: 20px;
 }
+
+.chapter-button {
+  padding: 10px 20px;
+  background-color: #e50914;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.button-container {
+  display: flex; /* Ensure buttons are laid out in a row */
+  justify-content: center;
+}
+
+.button-container .chapter-button:first-of-type {
+  margin-right: 10px; /* Add margin to the right of the first button */
+}
+
+.button-container .chapter-button:last-of-type {
+  margin-left: 10px; /* Add margin to the left of the second button */
+}

--- a/src/pages/MangaRead.js
+++ b/src/pages/MangaRead.js
@@ -4,62 +4,66 @@ import axios from 'axios';
 import ChapterDetail from './ChapterDetail';
 import './MangaRead.css';
 
+// Componente principal para exibir os capítulos de um mangá
 const MangaRead = () => {
-  const { id } = useParams();
-  const navigate = useNavigate();
-  const [chapters, setChapters] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [selectedChapter, setSelectedChapter] = useState('');
+  const { id } = useParams(); // Obtém o ID do mangá da URL
+  const navigate = useNavigate(); // Função para navegação entre páginas
+  const [chapters, setChapters] = useState([]); // Estado para armazenar a lista de capítulos
+  const [loading, setLoading] = useState(true); // Estado para controle de carregamento
+  const [selectedChapter, setSelectedChapter] = useState(''); // Estado para armazenar o capítulo selecionado
 
-
+  // Função para buscar os capítulos do mangá
   useEffect(() => {
     const fetchChapters = async () => {
       try {
+        // Solicita a lista de capítulos do mangá
         const response = await axios.get(`https://api.mangadex.org/manga/${id}/feed`, {
           params: {
-            translatedLanguage: ['pt-br'],
-            limit: 100,
+            translatedLanguage: ['pt-br'], // Filtra capítulos traduzidos para português
+            limit: 100, // Limita o número de capítulos retornados
             order: {
-              chapter: 'asc'
+              chapter: 'asc' // Ordena os capítulos em ordem crescente
             }
           }
         });
         const fetchedChapters = response.data.data;
-        setChapters(response.data.data);
+        setChapters(fetchedChapters); // Armazena os capítulos no estado
 
+        // Obtém o ID do último capítulo lido do armazenamento local
         const lastReadChapterId = localStorage.getItem(`lastReadChapter-${id}`);
         const initialChapterId = lastReadChapterId || (fetchedChapters.length > 0 ? fetchedChapters[0].id : '');
 
+        // Define o capítulo inicial a ser exibido
         if (initialChapterId) {
           setSelectedChapter(initialChapterId);
           navigate(`/manga/${id}/read/${initialChapterId}`);
         }
       } catch (error) {
-        console.error('Error fetching chapters:', error);
+        console.error('Error fetching chapters:', error); // Exibe erro caso a solicitação falhe
       } finally {
-        setLoading(false);
+        setLoading(false); // Finaliza o carregamento
       }
     };
 
     fetchChapters();
-  }, [id, navigate]);
+  }, [id, navigate]); // Reexecuta quando o ID do mangá ou a função de navegação muda
 
-
+  // Manipula a mudança de seleção do capítulo
   const handleChapterChange = (event) => {
     const selectedChapterId = event.target.value;
-    setSelectedChapter(selectedChapterId);
-    localStorage.setItem(`lastReadChapter-${id}`, selectedChapterId);
-    navigate(`/manga/${id}/read/${selectedChapterId}`);
-
+    setSelectedChapter(selectedChapterId); // Atualiza o capítulo selecionado
+    localStorage.setItem(`lastReadChapter-${id}`, selectedChapterId); // Armazena o capítulo selecionado no armazenamento local
+    navigate(`/manga/${id}/read/${selectedChapterId}`); // Navega para o capítulo selecionado
   };
 
-
+  // Exibe mensagem de carregamento enquanto os dados estão sendo obtidos
   if (loading) {
     return <div>Carregando...</div>;
   }
 
+  // Exibe mensagem se não houver capítulos disponíveis
   if (chapters.length === 0) {
-    return <div>No chapters available.</div>;
+    return <div>Não há capítulos disponíveis.</div>;
   }
 
   return (
@@ -78,7 +82,5 @@ const MangaRead = () => {
     </div>
   );
 };
-
-
 
 export default MangaRead;


### PR DESCRIPTION
## Alterações:

- Inserção de botões "Página anterior" e "Próxima página"
- Feita a lógica para iniciar o mangá no primeiro capítulo ou no último capítulo lido, levando o usuário ao topo (colocando o h1 como referência pra scrollar até o topo) quando o capítulo é trocado
- Restauração do README e do código no geral, apagado a partir do commit [5387011](https://github.com/Cbih939/MangasSA/commit/53870112d2272235e31da4bf931d33c7be75a714)

## Sugestões:

- [x] Pesquisa por título
- [x] Evitar que o header da página esconda a barra de scroll em desktop